### PR TITLE
Gains `test-filter_core.R`. Improved error messaged in `filter_core` …

### DIFF
--- a/R/functions/filter_core.R
+++ b/R/functions/filter_core.R
@@ -31,7 +31,10 @@ filter_core <- function(physeq, threshold = 0.6, as = "rows") {
   # Based on `orient_taxa()` https://github.com/mikemc/speedyseq/blob/0057652ff7a4244ccef2b786dca58d901ec2fc62/R/utils.R
   ensure_phyloseq_orientation <- function(physeq, as) {
     # Validate 'as' argument
-    stopifnot(as %in% c("rows", "columns", "cols"))
+    stopifnot(
+      "Arguments 'as' must be a string:'rows', 'cols' or 'columns'!" =
+        as %in% c("rows", "columns", "cols")
+    )
 
     # Ensure taxa are in the desired orientation
     if (identical(as, "rows")) {
@@ -49,10 +52,16 @@ filter_core <- function(physeq, threshold = 0.6, as = "rows") {
   physeq_rel <- ensure_phyloseq_orientation(physeq, as)
 
   # Calculate occurrence of each ASV across samples
-  asv_sample_counts <- rowSums(otu_table(physeq_rel) > 0)
-
   # Get total number of samples
-  total_samples <- ncol(otu_table(physeq_rel))
+  if (identical(as, "rows")) {
+    asv_sample_counts <- rowSums(otu_table(physeq_rel) > 0)
+    total_samples <- ncol(otu_table(physeq_rel))
+  }
+
+  if (identical(as, "cols") || identical(as, "columns")) {
+    asv_sample_counts <- colSums(otu_table(physeq_rel) > 0)
+    total_samples <- nrow(otu_table(physeq_rel))
+  }
 
   # Select ASVs based on occurrence criteria
   high_occurrence_asvs <- names(asv_sample_counts[asv_sample_counts >= total_samples * threshold])

--- a/tests/testthat/test-filter_core.R
+++ b/tests/testthat/test-filter_core.R
@@ -1,3 +1,104 @@
-test_that("multiplication works", {
-  expect_equal(2 * 2, 4)
+library(testthat)
+library(phyloseq)
+library(dplyr)
+library(waldo)
+list.files("R/functions/", full.names = TRUE) |>
+  lapply(source)
+
+
+# Load the esophagus dataset
+data(esophagus, package = "phyloseq")
+
+# Get the taxa names from the esophagus dataset
+taxa_names <- taxa_names(esophagus)
+
+# Define realistic taxonomy levels
+kingdoms <- c("Bacteria", "Archaea")
+phyla <- c("Firmicutes", "Bacteroidetes", "Proteobacteria", "Actinobacteria", "Euryarchaeota")
+classes <- c("Clostridia", "Bacteroidia", "Gammaproteobacteria", "Actinobacteria", "Methanobacteria")
+orders <- c("Clostridiales", "Bacteroidales", "Enterobacterales", "Bifidobacteriales", "Methanobacteriales")
+families <- c("Lachnospiraceae", "Bacteroidaceae", "Enterobacteriaceae", "Bifidobacteriaceae", "Methanobacteriaceae")
+genera <- c("Blautia", "Bacteroides", "Escherichia", "Bifidobacterium", "Methanobrevibacter")
+species <- c("Blautia producta", "Bacteroides fragilis", "Escherichia coli", "Bifidobacterium longum", "Methanobrevibacter smithii")
+
+# Create a mock taxonomy table
+mock_taxonomy_table <- matrix(
+  c(
+    sample(kingdoms, length(taxa_names), replace = TRUE),
+    sample(phyla, length(taxa_names), replace = TRUE),
+    sample(classes, length(taxa_names), replace = TRUE),
+    sample(orders, length(taxa_names), replace = TRUE),
+    sample(families, length(taxa_names), replace = TRUE),
+    sample(genera, length(taxa_names), replace = TRUE),
+    sample(species, length(taxa_names), replace = TRUE)
+  ),
+  nrow = length(taxa_names),
+  ncol = 7,
+  dimnames = list(
+    taxa_names,
+    c("Kingdom", "Phylum", "Class", "Order", "Family", "Genus", "Species")
+  )
+)
+
+# Convert to a taxonomy table object
+tax_table <- tax_table(mock_taxonomy_table)
+
+# Add sample metadata to the esophagus dataset (required for calculate_nmds)
+sample_data <- data.frame(
+  Sample = sample_names(esophagus),
+  Group = sample(c("A", "B"), nsamples(esophagus), replace = TRUE), # Random groups
+  row.names = sample_names(esophagus)
+)
+
+# Add the taxonomy table to the esophagus dataset
+esophagus_with_tax <- merge_phyloseq(esophagus, tax_table, sample_data(sample_data))
+
+# Test suite
+test_that("filter_core() works with esophagus dataset", {
+  # Test 1: Basic functionality
+  results <- filter_core(esophagus_with_tax, threshold = 0.6, as = "rows")
+
+  expect_named(results, c("physeq_high_occ", "physeq_low_occ"))
+  expect_s4_class(results$physeq_high_occ, "phyloseq")
+  expect_s4_class(results$physeq_low_occ, "phyloseq")
+
+  # Test 2: Check high occurrence ASVs
+  high_occ_asvs <- taxa_names(results$physeq_high_occ)
+  expect_true(length(high_occ_asvs) > 0)
+  expect_true(all(rowSums(otu_table(results$physeq_high_occ) > 0) >= 2)) # 60% of 3 samples
+
+  # Test 3: Check low occurrence ASVs
+  low_occ_asvs <- taxa_names(results$physeq_low_occ)
+  expect_true(length(low_occ_asvs) > 0)
+  expect_true(all(rowSums(otu_table(results$physeq_low_occ) > 0) < 2)) # Less than 60% of 10 samples
+
+  # Test 4: Edge case - threshold = 0 (all ASVs are high occurrence)
+  expect_error(filter_core(esophagus_with_tax, threshold = 0.0, as = "rows"))
+
+  # Test 5: Edge case - threshold = 1 (all ASVs are low occurrence)
+  results_threshold_1 <- filter_core(esophagus_with_tax, threshold = 1, as = "rows")
+  expect_equal(ntaxa(results_threshold_1$physeq_high_occ), 14)
+  expect_equal(ntaxa(results_threshold_1$physeq_low_occ), 44)
+
+  # Test 6: Invalid threshold
+  expect_error(filter_core(esophagus_with_tax, threshold = -1, as = "rows"), "must be between 0 and 1")
+  expect_error(filter_core(esophagus_with_tax, threshold = 2, as = "rows"), "must be between 0 and 1")
+
+  # Test 7: Invalid phyloseq object
+  expect_error(filter_core("not_a_phyloseq_object", threshold = 0.6, as = "rows"), "must be a phyloseq object")
+
+  # Test 8: Invalid 'as' argument
+  expect_error(
+    filter_core(esophagus_with_tax, threshold = 0.6, as = "invalid"),
+    "Arguments 'as' must be a string:'rows', 'cols' or 'columns'!"
+  )
+
+  # Test 9: Check taxa orientation
+  results_rows <- filter_core(esophagus_with_tax, threshold = 0.6, as = "rows")
+  results_cols <- filter_core(esophagus_with_tax, threshold = 0.6, as = "columns")
+
+  expect_true(taxa_are_rows(results_rows$physeq_high_occ))
+  expect_true(taxa_are_rows(results_rows$physeq_low_occ))
+  expect_false(taxa_are_rows(results_cols$physeq_high_occ))
+  expect_false(taxa_are_rows(results_cols$physeq_low_occ))
 })


### PR DESCRIPTION
## Overview

Here I introduce tests fro `filter_core` function. Improvements on error message and handling were needed for tests to pass, specially when using `stopifnot()` in `ensure_phyloseq_orientation` helper function.  Depending on the orientation of the taxa , the calculation of ASVs acorss samples and total number of samples needed adjustment. Calculates occurrence of ASVs across samples and total number of samples correctly according to the orientation of the taxa.

## Tests
- All tests passed.


